### PR TITLE
Added coverage tests for repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added test cases for users handlers. [#8](https://github.com/marcosstupnicki/go-users/pull/8)
+- Added test case to internal service. Decouple db structure. [#7](https://github.com/marcosstupnicki/go-users/pull/7)
+- Added test case to configs. Minor structure refactor. [#6](https://github.com/marcosstupnicki/go-users/pull/6)
 - Minor refactor following Package Oriented Design. Dependency Injection. [#5](https://github.com/marcosstupnicki/go-users/pull/5)
 - Use bcrypt to hash user password. [#4](https://github.com/marcosstupnicki/go-users/pull/4)
 - Added functionality to load configurations from a struct. [#3](https://github.com/marcosstupnicki/go-users/pull/3)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt lint test test-cover all
+.PHONY: help fmt lint tests all
 
 # Basic Makefile for Golang project
 # Includes GRPC Gateway, Protocol Buffers
@@ -12,15 +12,19 @@ help:   ## show this help
 	@echo 'targets:'
 	@egrep '^(.+)\:\ .*##\ (.+)' ${MAKEFILE_LIST} | sed 's/:.*##/#/' | column -t -c 2 -s '#'
 
-tests:
+tests:  ## execute the go source tests.
 	echo "Executing tests"
 	go test ./...
 
-fmt:    ## format the go source files
-	echo "Formating tests"
+coverage:  ## execute the go source tests with code coverage info.
+	echo "Executing tests with coverage"
+	go test -coverprofile=coverage.out ./... ;    go tool cover -html=coverage.out
+
+fmt:  ## format the go source files.
+	echo "Formatting files"
 	go fmt ./...
 	goimports -w $(FILES)
 
-tools:  ## fetch and install all required tools
+tools:  ## fetch and install all required tools.
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u github.com/golang/lint/golint

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ module github.com/marcosstupnicki/go-users
 go 1.16
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/marcosstupnicki/go-webapp v1.4.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi v1.5.4 h1:QHdzF2szwjqVV4wmByUnTcsbIg7UGaQ0tPF2t5GcAIs=

--- a/internal/users/mysql.go
+++ b/internal/users/mysql.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	// ErrUserNotFound record not found error
+	// ErrUserNotFound users not found error
 	ErrUserNotFound = errors.New("user not found")
 )
 
@@ -71,13 +71,14 @@ func (repository MySQL) Delete(id int) error {
 	user := User{ID: id}
 
 	tx := repository.DB.Delete(&user)
+	if tx.Error != nil {
+		return tx.Error
+	}
+
 	if tx.RowsAffected == 0 {
 		return ErrUserNotFound
 	}
 
-	if tx.Error != nil {
-		return tx.Error
-	}
 
 	return nil
 }

--- a/internal/users/mysql_test.go
+++ b/internal/users/mysql_test.go
@@ -1,0 +1,301 @@
+package users
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+func TestMySQL_Create(t *testing.T) {
+	user := User{
+		Email:    "some@email.com",
+		Password: "$2a$10$i8u5FgiJXRui/p.ZDXnDO.kVq3H6rbqrQp6rInFX.IeEO0zN/2F5G",
+	}
+
+	var tests = []struct {
+		name           string
+		user           User
+		db             *gorm.DB
+		expectedResult User
+		expectedError  error
+	}{
+		{
+			name: "Ok - Create",
+			user: user,
+			db: func() *gorm.DB {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+
+				mock.MatchExpectationsInOrder(false)
+				mock.ExpectBegin()
+				mock.ExpectExec("INSERT INTO `users`").
+					WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectCommit()
+
+				gormDB, err := gorm.Open(
+					mysql.New(mysql.Config{
+						Conn:                      db,
+						SkipInitializeWithVersion: true}),
+					&gorm.Config{})
+				require.NoError(t, err)
+
+				return gormDB
+			}(),
+			expectedResult: User{
+				ID:        0,
+				Email:     "some@email.com",
+				Password:  "$2a$10$i8u5FgiJXRui/p.ZDXnDO.kVq3H6rbqrQp6rInFX.IeEO0zN/2F5G",
+				CreatedAt: time.Now().Unix(),
+				UpdatedAt: time.Now().Unix(),
+			},
+		},
+		{
+			name: "Fail - Internal error",
+			user: user,
+			db: func() *gorm.DB {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+
+				mock.MatchExpectationsInOrder(false)
+				mock.ExpectBegin()
+				mock.ExpectExec("INSERT INTO `users`").
+					WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+					WillReturnError(errors.New("internal error"))
+				mock.ExpectCommit()
+				mock.ExpectRollback()
+
+				gormDB, err := gorm.Open(
+					mysql.New(mysql.Config{
+						Conn:                      db,
+						SkipInitializeWithVersion: true}),
+					&gorm.Config{})
+				require.NoError(t, err)
+
+				return gormDB
+			}(),
+			expectedError: errors.New("internal error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			repo := MySQL{
+				DB: tt.db,
+			}
+			result, err := repo.Create(tt.user)
+
+			require.Equal(t, tt.expectedError, err)
+			require.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestMySQL_Get(t *testing.T) {
+	var tests = []struct {
+		name           string
+		id             int
+		db             *gorm.DB
+		expectedResult User
+		expectedError  error
+	}{
+		{
+			name: "Ok - Get user",
+			id:   1,
+			db: func() *gorm.DB {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+				rows := sqlmock.NewRows([]string{"id", "email", "password", "created_at", "updated_at"}).
+					AddRow(1, "some@email.com", "$2a$10$i8u5FgiJXRui/p.ZDXnDO.kVq3H6rbqrQp6rInFX.IeEO0zN/2F5G", 123456, 123456)
+
+				mock.MatchExpectationsInOrder(false)
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(sqlmock.AnyArg()).
+					WillReturnRows(rows)
+
+				gormDB, err := gorm.Open(
+					mysql.New(mysql.Config{
+						Conn:                      db,
+						SkipInitializeWithVersion: true}),
+					&gorm.Config{})
+				require.NoError(t, err)
+
+				return gormDB
+			}(),
+			expectedResult: User{
+				ID: 1,
+				Email: "some@email.com",
+				Password: "$2a$10$i8u5FgiJXRui/p.ZDXnDO.kVq3H6rbqrQp6rInFX.IeEO0zN/2F5G",
+				CreatedAt: 123456,
+				UpdatedAt: 123456,
+			},
+		},
+		{
+			name: "Fail - User not found",
+			id:   1,
+			db: func() *gorm.DB {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+
+				row := sqlmock.NewRows([]string{"id", "email", "password", "created_at", "updated_at"})
+
+				mock.MatchExpectationsInOrder(false)
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(sqlmock.AnyArg()).
+					WillReturnRows(row)
+
+				gormDB, err := gorm.Open(
+					mysql.New(mysql.Config{
+						Conn:                      db,
+						SkipInitializeWithVersion: true}),
+					&gorm.Config{})
+				require.NoError(t, err)
+
+				return gormDB
+			}(),
+			expectedError: ErrUserNotFound,
+		},
+		{
+			name: "Fail - Internal error",
+			id:   1,
+			db: func() *gorm.DB {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+
+				mock.MatchExpectationsInOrder(false)
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT 1")).
+					WithArgs(sqlmock.AnyArg()).
+					WillReturnError(errors.New("internal error"))
+
+				gormDB, err := gorm.Open(
+					mysql.New(mysql.Config{
+						Conn:                      db,
+						SkipInitializeWithVersion: true}),
+					&gorm.Config{})
+				require.NoError(t, err)
+
+				return gormDB
+			}(),
+			expectedError: ErrUserNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			repo := MySQL{
+				DB: tt.db,
+			}
+			result, err := repo.Get(tt.id)
+
+			require.Equal(t, tt.expectedError, err)
+			require.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestMySQL_Delete(t *testing.T) {
+	var tests = []struct {
+		name           string
+		id             int
+		db             *gorm.DB
+		expectedError  error
+	}{
+		{
+			name: "Ok - Delete user",
+			id:   1,
+			db: func() *gorm.DB {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+
+				mock.MatchExpectationsInOrder(false)
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE")).
+					WithArgs(sqlmock.AnyArg()).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+
+				gormDB, err := gorm.Open(
+					mysql.New(mysql.Config{
+						Conn:                      db,
+						SkipInitializeWithVersion: true}),
+					&gorm.Config{})
+				require.NoError(t, err)
+
+				return gormDB
+			}(),
+		},
+		{
+			name: "Fail - User not found",
+			id:   1,
+			db: func() *gorm.DB {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+
+				mock.MatchExpectationsInOrder(false)
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE")).
+					WithArgs(sqlmock.AnyArg()).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectCommit()
+
+				gormDB, err := gorm.Open(
+					mysql.New(mysql.Config{
+						Conn:                      db,
+						SkipInitializeWithVersion: true}),
+					&gorm.Config{})
+				require.NoError(t, err)
+
+				return gormDB
+			}(),
+			expectedError: ErrUserNotFound,
+		},
+		{
+			name: "Fail - Internal error",
+			id:   1,
+			db: func() *gorm.DB {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+
+				mock.MatchExpectationsInOrder(false)
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE")).
+					WithArgs(sqlmock.AnyArg()).
+					WillReturnError(errors.New("internal error"))
+				mock.ExpectRollback()
+
+				gormDB, err := gorm.Open(
+					mysql.New(mysql.Config{
+						Conn:                      db,
+						SkipInitializeWithVersion: true}),
+					&gorm.Config{})
+				require.NoError(t, err)
+
+				return gormDB
+			}(),
+			expectedError: errors.New("internal error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			repo := MySQL{
+				DB: tt.db,
+			}
+			err := repo.Delete(tt.id)
+
+			require.Equal(t, tt.expectedError, err)
+		})
+	}
+}

--- a/internal/users/service.go
+++ b/internal/users/service.go
@@ -1,8 +1,6 @@
 package users
 
 import (
-	"log"
-
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -90,7 +88,6 @@ func generatePassword(plainPassword string) (string, error) {
 	// Generate "hash" to mysql from user password.
 	hash, err := bcrypt.GenerateFromPassword([]byte(plainPassword), bcrypt.DefaultCost)
 	if err != nil {
-		log.Fatal(err)
 		return "", err
 	}
 


### PR DESCRIPTION
This PR adds coverage tests for the MySQL repository using go-sqlmock.
Additionally, a rule is added to the Makefile to execute the tests with coverage.

Related links:
Go unit tests with coverage >
https://stackoverflow.com/a/65454318
https://blog.seriesci.com/how-to-measure-code-coverage-in-go

[DATA-DOG/go-sqlmock](github.com/DATA-DOG/go-sqlmock) >
https://github.com/DATA-DOG/go-sqlmock
https://stackoverflow.com/questions/41510003/golang-gorm-mocking
https://stackoverflow.com/questions/50164399/sqlmock-with-gorm-insert
https://stackoverflow.com/questions/62507911/sqlmock-mocking-out-chained-delete-query